### PR TITLE
fix pubkey issue

### DIFF
--- a/luci-app-amneziawg/root/usr/share/rpcd/ucode/luci.amneziawg
+++ b/luci-app-amneziawg/root/usr/share/rpcd/ucode/luci.amneziawg
@@ -26,7 +26,7 @@ const methods = {
 	generateKeyPair: {
 		call: function() {
 			const priv = command('amneziawg genkey 2>/dev/null');
-			const pub = command(`echo ${shellquote(priv)} | wg pubkey 2>/dev/null`);
+			const pub = command(`echo ${shellquote(priv)} | amneziawg pubkey 2>/dev/null`);
 
 			return { keys: { priv, pub } };
 		}
@@ -36,7 +36,7 @@ const methods = {
 		args: { privkey: "privkey" },
 		call: function(req) {
 			const priv = req.args?.privkey;
-			const pub = command(`echo ${shellquote(priv)} | wg pubkey 2>/dev/null`);
+			const pub = command(`echo ${shellquote(priv)} | amneziawg pubkey 2>/dev/null`);
 
 			return { keys: { priv, pub } };
 		}


### PR DESCRIPTION
This PR fixes the issue with the wrong tool invoked.
The issue may NOT appear on systems where both wireguard tools and awg tools are installed. However, on the clean installation, there is no `wg` tool which leads to the issue of getting the public key and breaking the UI.

![image](https://github.com/amnezia-vpn/amneziawg-openwrt/assets/6585448/9085dbcd-5924-4262-9e27-6a6b520aa93a)
